### PR TITLE
Fix a bug in answer() function inside the Xonomy.editRaw()

### DIFF
--- a/xonomy.js
+++ b/xonomy.js
@@ -1135,12 +1135,13 @@ Xonomy.editRaw=function(htmlID, parameter) {
 	document.body.appendChild(Xonomy.makeBubble(Xonomy.askLongString(txt))); //create bubble
 	Xonomy.showBubble($(div)); //anchor bubble to element
 	Xonomy.answer=function(val) {
-		if(parameter.toJs) var jsElement=parameter.toJs(val, jsElement);
-		else if(parameter.toXml) var jsElement=Xonomy.xml2js(parameter.toXml(val, jsElement));
-		else jsElement=Xonomy.xml2js(val);
+		var jsNewElement;
+		if(parameter.toJs) jsNewElement=parameter.toJs(val, jsElement);
+		else if(parameter.toXml) jsNewElement=Xonomy.xml2js(parameter.toXml(val, jsElement));
+		else jsNewElement=Xonomy.xml2js(val);
 
 		var obj=document.getElementById(htmlID);
-		var html=Xonomy.renderElement(jsElement);
+		var html=Xonomy.renderElement(jsNewElement);
 		$(obj).replaceWith(html);
 		Xonomy.clickoff();
 		Xonomy.changed();


### PR DESCRIPTION
The following statement is probably not what was intended:

  ```
var jsElement=...;
  Xonomy.answer=function(val) {
    ...
    var jsElement=parameter.toJs(val, jsElement);
  }
```
The `parameter.toJs()` function is called with `undefined` as
a second argument and not with `jsElement` closure as intended.

Inside the `Xonomy.answer()` function the `jsElement` is declared
as a new variable and so the closure value is hidden
in the whole function scope.