### PR TITLE
Add support for hierarchical menus

### DIFF
--- a/xonomy.css
+++ b/xonomy.css
@@ -153,6 +153,9 @@
 
 /*When the pop-up box functions as menu or picker*/
 #xonomyBubble.nerd #xonomyBubbleContent div.menu { margin: -5px; max-height: 250px; overflow-y: auto; white-space: nowrap; }
+#xonomyBubble.nerd #xonomyBubbleContent div.submenu { position: absolute; display: none; }
+#xonomyBubble.nerd #xonomyBubbleContent div.menuItem:hover div { position: relative; padding: 4px; display: block; }
+#xonomyBubble.nerd #xonomyBubbleContent div.submenu div.menuItem:hover { background: #fbf4b8; }
 #xonomyBubble.nerd #xonomyBubbleContent div.menuItem { padding: 8px 20px 7px 10px; border-top: 1px solid #dddddd; cursor: pointer; margin-top: -1px; }
 #xonomyBubble.nerd #xonomyBubbleContent span.techno { font-family: monospace; font-size: 0.9rem; }
 #xonomyBubble.nerd #xonomyBubbleContent span.techno span.punc {color: #669acc; }
@@ -348,6 +351,9 @@
 
 /*When the pop-up box functions as menu or picker*/
 #xonomyBubble.laic #xonomyBubbleContent div.menu { margin: -10px; max-height: 250px; overflow-y: auto; white-space: nowrap; }
+#xonomyBubble.laic #xonomyBubbleContent div.submenu { position: absolute; display: none; }
+#xonomyBubble.laic #xonomyBubbleContent div.menuItem:hover div { position: relative; padding: 4px; display: block; }
+#xonomyBubble.laic #xonomyBubbleContent div.submenu div.menuItem:hover { background: #fbf4b8; }
 #xonomyBubble.laic #xonomyBubbleContent div.menuItem { padding: 10px 20px 10px 10px; border-top: 1px solid #dddddd; cursor: pointer; margin-top: -1px; }
 #xonomyBubble.laic #xonomyBubbleContent .techno { font-family: monospace; font-size: 0.85rem; color: #444444; }
 #xonomyBubble.laic #xonomyBubbleContent .techno span.atName { font-family: Verdana, sans-serif; font-weight: bold; color: #6385bf; }

--- a/xonomy.js
+++ b/xonomy.js
@@ -964,60 +964,48 @@ Xonomy.wyc=function(url, callback){ //a "when-you-can" function for delayed rend
 	return "<span class='wyc' id='"+wycID+"'></span>";
 };
 
+Xonomy.internalMenu=function(htmlID, items, harvest, getter) {
+	var fragments = items.map(function (item, i) {
+		Xonomy.verifyDocSpecMenuItem(item);
+		var jsMe=harvest(document.getElementById(htmlID));
+		var includeIt=!item.hideIf(jsMe);
+		var html="";
+		if(includeIt) {
+			html+="<div class='menuItem' onclick='Xonomy.callMenuFunction("+getter(i)+", \""+htmlID+"\")'>";
+			html+=Xonomy.formatCaption(Xonomy.textByLang(item.caption(jsMe)));
+			html+="</div>";
+			}
+		return html;
+		});
+	return fragments.length
+		? "<div class='menu'>"+fragments.join("")+"</div>"
+		: "";
+};
 Xonomy.attributeMenu=function(htmlID) {
 	var name=$("#"+htmlID).attr("data-name"); //obtain attribute's name
 	var elName=$("#"+htmlID).closest(".element").attr("data-name"); //obtain element's name
 	Xonomy.verifyDocSpecAttribute(elName, name);
 	var spec=Xonomy.docSpec.elements[elName].attributes[name];
-	var html="";
-	for(var i=0; i<spec.menu.length; i++) {
-		var item=spec.menu[i];
-		Xonomy.verifyDocSpecMenuItem(item);
-		var jsMe=Xonomy.harvestAttribute(document.getElementById(htmlID));
-		var includeIt=!item.hideIf(jsMe);
-		if(includeIt) {
-			html+="<div class='menuItem' onclick='Xonomy.callMenuFunction(Xonomy.docSpec.elements[\""+elName+"\"].attributes[\""+name+"\"].menu["+i+"], \""+htmlID+"\")'>";
-			html+=Xonomy.formatCaption(Xonomy.textByLang(item.caption(jsMe)));
-			html+="</div>";
-		}
+	function getter(i) {
+		return 'Xonomy.docSpec.elements["'+elName+'"].attributes["'+name+'"].menu['+i+']';
 	}
-	if(html!="") html="<div class='menu'>"+html+"</div>";
-	return html;
+	return Xonomy.internalMenu(htmlID, spec.menu, Xonomy.harvestAttribute, getter);
 };
 Xonomy.elementMenu=function(htmlID) {
 	var elName=$("#"+htmlID).attr("data-name"); //obtain element's name
 	var spec=Xonomy.docSpec.elements[elName];
-	var html="";
-	for(var i=0; i<spec.menu.length; i++) {
-		var item=spec.menu[i];
-		Xonomy.verifyDocSpecMenuItem(item);
-		var jsMe=Xonomy.harvestElement(document.getElementById(htmlID));
-		var includeIt=!item.hideIf(jsMe);
-		if(includeIt) {
-			html+="<div class='menuItem' onclick='Xonomy.callMenuFunction(Xonomy.docSpec.elements[\""+elName+"\"].menu["+i+"], \""+htmlID+"\")'>";
-			html+=Xonomy.formatCaption(Xonomy.textByLang(item.caption(jsMe)));
-			html+="</div>";
-		}
+	function getter(i) {
+		return 'Xonomy.docSpec.elements["'+elName+'"].menu['+i+']';
 	}
-	if(html!="") html="<div class='menu'>"+html+"</div>";
-	return html;
+	return Xonomy.internalMenu(htmlID, spec.menu, Xonomy.harvestElement, getter);
 };
 Xonomy.inlineMenu=function(htmlID) {
 	var elName=$("#"+htmlID).attr("data-name"); //obtain element's name
 	var spec=Xonomy.docSpec.elements[elName];
-	var html="";
-	for(var i=0; i<spec.inlineMenu.length; i++) {
-		var item=spec.inlineMenu[i];
-		var jsMe=Xonomy.harvestElement(document.getElementById(htmlID));
-		var includeIt=!item.hideIf(Xonomy.harvestElement(document.getElementById(htmlID)));
-		if(includeIt) {
-			html+="<div class='menuItem' onclick='Xonomy.callMenuFunction(Xonomy.docSpec.elements[\""+elName+"\"].inlineMenu["+i+"], \""+htmlID+"\")'>";
-			html+=Xonomy.formatCaption(Xonomy.textByLang(item.caption(jsMe)));
-			html+="</div>";
-		}
+	function getter(i) {
+		return 'Xonomy.docSpec.elements["'+elName+'"].inlineMenu['+i+']';
 	}
-	if(html!="") html="<div class='menu'>"+html+"</div>";
-	return html;
+	return Xonomy.internalMenu(htmlID, spec.inlineMenu, Xonomy.harvestElement, getter);
 };
 Xonomy.callMenuFunction=function(menuItem, htmlID) {
 	menuItem.action(htmlID, menuItem.actionParameter);


### PR DESCRIPTION
Newly the following hierarchical menu is supported:
```
var docSpec={
  elements: {
    item: {
      menu: [{
        caption: "Add attribute",
        menu: [
          {caption: "Add @name=\"something\"", ...},
          {caption: "Add @desc=\"something\"", ...}
        ]
      }, {
        caption: "Delete this <item>",
        action: Xonomy.deleteElement
      }, {
        caption: "New <item>",
        menu: [
         {caption: "New <item> before this", ...},
         {caption: "New <item> after this", ...}
        ]
     }],
    }
  }
};
```
New function `Xonomy.internalMenu()` is called from all the `Xonomy.[element|attribute|inline]Menu` handlers and performs all the common stuff. It accepts array of indices and transforms it to a hierarchical menu item lookup code and also distinguishes between _menu_ and _submenu_ `div` classes.

CSS stylesheet is updated to support hierarchical menus.