### PR TITLE
wyc_method Allow other request methods on wyc

### DIFF
--- a/xonomy.js
+++ b/xonomy.js
@@ -1015,11 +1015,11 @@ Xonomy.pickerMenu=function(picklist, defaultString){
 
 Xonomy.wycLastID=0;
 Xonomy.wycCache={};
-Xonomy.wyc=function(url, callback){ //a "when-you-can" function for delayed rendering: gets json from url, passes it to callback, and delayed-returns html-as-string from callback
+Xonomy.wyc=function(url, callback, method){ //a "when-you-can" function for delayed rendering: gets json from url, passes it to callback, and delayed-returns html-as-string from callback
 	Xonomy.wycLastID++;
 	var wycID="xonomy_wyc_"+Xonomy.wycLastID;
 	if(Xonomy.wycCache[url]) return callback(Xonomy.wycCache[url]);
-	$.ajax({url: url, dataType: "json", method: "POST"}).done(function(data){
+	$.ajax({url: url, dataType: "json", method: method || "POST"}).done(function(data){
 			$("#"+wycID).replaceWith(callback(data));
 			Xonomy.wycCache[url]=data;
 	});


### PR DESCRIPTION
POST is not that well suited for getting data from the server. GET would
be better. Xonomy will still default to POST requests, but can now be
told to make GET requests.