### PR TITLE
whisper-text Use displayed text as whispers

### DIFF
--- a/xonomy.js
+++ b/xonomy.js
@@ -722,7 +722,7 @@ Xonomy.updateCollapsoid=function(htmlID) {
 	} else {
 		var abbreviated=false;
 		$element.find(".textnode").each(function(){
-			var txt=Xonomy.harvestText(this).value;
+			var txt=$(this).text();
 			for(var i=0; i<txt.length; i++) {
 				if(whisper.length<35) whisper+=txt[i]; else abbreviated=true;
 			}


### PR DESCRIPTION
data-value does not always match the displayed value. It seems more
user friendly to use displayed value as whisper on collapsoids.